### PR TITLE
content-disposition

### DIFF
--- a/check-version.sh
+++ b/check-version.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-targetName=$(curl -sI "https://dl.pstmn.io/download/latest/linux64" | grep "content-disposition" | awk -F '=' '{ print $2 }')
+targetName=$(curl -sI "https://dl.pstmn.io/download/latest/linux64" | grep -i "content-disposition" | awk -F '=' '{ print $2 }')
 versionMaj=$(echo "$targetName" | awk -F '-' '{ print $4 }' | awk -F '.' '{ print $1 }')
 versionMin=$(echo "$targetName" | awk -F '-' '{ print $4 }' | awk -F '.' '{ print $2 }')
 versionRev=$(echo "$targetName" | awk -F '-' '{ print $4 }' | awk -F '.' '{ print $3 }')


### PR DESCRIPTION
-i is for case insensitive - there is alot of chances that the original grep dont respond at all without such toggle.

i suggest 

`curl -sI 'https://dl.pstmn.io/download/latest/linux64' | grep -Pio "filename=Postman-linux-x86_64-\K(\d+\.)?(\d+\.)?(\*|\d+)"`

change the regex to `"filename=.+-\K(\d+\.)?(\d+\.)?(\*|\d+)"` to match all future stuff with os changes and archiceture